### PR TITLE
Inform user when using a multi-config cmake generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,14 @@ message(STATUS "Header files will be installed to: ${CMAKE_INSTALL_PREFIX}/${INC
 message(STATUS "Executables will be installed in: ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}")
 message(STATUS "CMake config-files will be written to: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DIR}")
 message(STATUS "${PROJECT_NAME} import target: ${PROJECT_NAMESPACE}::${TARGET_NAME}")
-message(STATUS "Building ${PROJECT_NAME} ${FULL_VERSION} in ${CMAKE_BUILD_TYPE} mode")
+if (CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "You are using a Multi-Configuration CMake Generator.")
+  message(STATUS "${PROJECT_NAME} ${FULL_VERSION} can be built for: "
+                 "${CMAKE_CONFIGURATION_TYPES}. Please be sure to specifiy the"
+                 " desired configuration to the compiler.")
+else ()
+  message(STATUS "Building ${PROJECT_NAME} ${FULL_VERSION} in ${CMAKE_BUILD_TYPE} mode")
+endif ()
 if (PRIVATE_TESTS_ENABLED)
   message(STATUS "Private tests are enabled")
 endif()


### PR DESCRIPTION
When using XCode or Visual Studio - like Multi-Configuration CMake generators,
it does not suffice to specifiy the CMAKE_BUILD_TYPE before running the build.
In this case, the user needs to pass a flag to the compiler. This change will inform
the user that this is necessary.