### PR TITLE
Move namespace dependent information to access ticket.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   ############################################################################
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      sudo apt-add-repository -y ppa:beineri/opt-qt57-trusty
+      sudo apt-add-repository -y ppa:beineri/opt-qt571-trusty
       sudo apt-get -qq update
       sudo apt-get -qq install qt57tools qt57websockets
       
@@ -50,7 +50,7 @@ install:
       brew tap homebrew/versions
       brew install qt5
       
-      export QTDIR="/usr/local/Cellar/qt5/5.7.0"
+      export QTDIR="/usr/local/opt/qt5"
       export PATH="$QTDIR/bin:$PATH"
     fi
     

--- a/examples/pubsub.cpp
+++ b/examples/pubsub.cpp
@@ -2,12 +2,15 @@
 #include <QString>
 #include <QDebug>
 #include <QProcessEnvironment>
+#include <QDateTime>
 #include "qawsiotclient.h"
 #include "qmqttprotocol.h"
 
 int main(int argc, char *argv[])
 {
     QCoreApplication a(argc, argv);
+
+    qRegisterMetaType<QMqttProtocol::State>("QMqttProtocol::State");
 
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     if (!env.contains(QStringLiteral("AWS_ACCESS_KEY_ID")) ||
@@ -45,8 +48,9 @@ int main(int argc, char *argv[])
                    [](const QString &topicName, const QByteArray &message) {
         qDebug() << "Received message on topic" << topicName << ":" << message;
     });
-
-    client.connect(hostname, region, accessKeyId, secretAccessKey, sessionToken);
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    client.connect(hostname, region, QString(), QByteArray(), now,
+                   accessKeyId, secretAccessKey, sessionToken);
 
     return a.exec();
 }

--- a/src/qawsiotclient.h
+++ b/src/qawsiotclient.h
@@ -15,15 +15,16 @@ class QTAWSIOT_EXPORT QAwsIoTClient: public QObject
     Q_DECLARE_PRIVATE(QAwsIoTClient)
 
 public:
-    QAwsIoTClient(const QString &clientId, const QString &willTopic, const QByteArray &willMessage);
     QAwsIoTClient(const QString &clientId);
     virtual ~QAwsIoTClient();
 
     QString region() const;
 
     using QObject::connect;
-    void connect(const QString &hostName, const QString &region, const QString &accessKeyId,
-                 const QString &secretAccessKey, const QString &sessionToken = QString());
+    void connect(const QString &hostName, const QString &region, const QString &willTopic,
+                 const QByteArray &willMessage, qint64 timestamp,
+                 const QString &accessKeyId, const QString &secretAccessKey,
+                 const QString &sessionToken = QString());
     using QObject::disconnect;
     void disconnect();
 

--- a/src/qawsiotclient_p.h
+++ b/src/qawsiotclient_p.h
@@ -15,13 +15,12 @@ class QAwsIoTClientPrivate: public QObject
     Q_DECLARE_PUBLIC(QAwsIoTClient)
 
 public:
-    QAwsIoTClientPrivate(const QString &clientId,
-                         const QString &willTopic, const QByteArray &willMessage,
-                         QAwsIoTClient * const q);
     QAwsIoTClientPrivate(const QString &clientId, QAwsIoTClient * const q);
     virtual ~QAwsIoTClientPrivate();
 
-    void connect(const QString &hostName, const QString &region, const QString &accessKeyId,
+    void connect(const QString &hostName, const QString &region,
+                 const QString &willTopic, const QByteArray &willMessage,
+                 qint64 timestamp, const QString &accessKeyId,
                  const QString &secretAccessKey, const QString &sessionToken);
     void disconnect();
     void subscribe(const QString &topic, QMqttProtocol::QoS qos, std::function<void(bool)> cb);

--- a/src/qawsiotnetworkrequest.cpp
+++ b/src/qawsiotnetworkrequest.cpp
@@ -50,7 +50,6 @@ void QAwsIoTNetworkRequest::signRequest(const QString &region,
     QVector<QString> headerNamesToEncode = { "host", "X-Amz-Date" };
     const QString hashingAlgorithm = "AWS4-HMAC-SHA256";
     const QDateTime current = QDateTime::fromMSecsSinceEpoch(timestamp).toUTC();
-    //const QDateTime current = QDateTime::currentDateTimeUtc();
 
     const QString &credentialScope =
             getDateString(current) + "/" + region + "/" + serviceName +"/aws4_request";

--- a/src/qawsiotnetworkrequest.cpp
+++ b/src/qawsiotnetworkrequest.cpp
@@ -32,23 +32,26 @@ inline QString getDateString(const QDateTime &date)
 QAwsIoTNetworkRequest::QAwsIoTNetworkRequest(const QString &region, const QString &hostname,
                                              const QString &accessKeyId,
                                              const QString &secretAccessKey,
-                                             const QString &sessionToken) :
+                                             const QString &sessionToken,
+                                             qint64 timestamp) :
     QMqttNetworkRequest()
 {
-    signRequest(region, hostname, "iotdata", accessKeyId, secretAccessKey, sessionToken);
+    signRequest(region, hostname, "iotdata", accessKeyId, secretAccessKey, sessionToken, timestamp);
 }
-
 
 void QAwsIoTNetworkRequest::signRequest(const QString &region,
                                         const QString &hostname,
                                         const QString &serviceName,
                                         const QString &accessKeyId,
                                         const QString &secretAccessKey,
-                                        const QString &sessionToken)
+                                        const QString &sessionToken,
+                                        qint64 timestamp)
 {
     QVector<QString> headerNamesToEncode = { "host", "X-Amz-Date" };
     const QString hashingAlgorithm = "AWS4-HMAC-SHA256";
-    const QDateTime current = QDateTime::currentDateTimeUtc();
+    const QDateTime current = QDateTime::fromMSecsSinceEpoch(timestamp).toUTC();
+    //const QDateTime current = QDateTime::currentDateTimeUtc();
+
     const QString &credentialScope =
             getDateString(current) + "/" + region + "/" + serviceName +"/aws4_request";
 

--- a/src/qawsiotnetworkrequest_p.h
+++ b/src/qawsiotnetworkrequest_p.h
@@ -12,7 +12,7 @@ class QTAWSIOT_AUTOTEST_EXPORT QAwsIoTNetworkRequest: public QMqttNetworkRequest
 public:
     QAwsIoTNetworkRequest(const QString &region, const QString &hostname,
                           const QString &accessKeyId, const QString &secretAccessKey,
-                          const QString &sessionToken);
+                          const QString &sessionToken, qint64 timestamp);
     virtual ~QAwsIoTNetworkRequest() = default;
     QAwsIoTNetworkRequest(const QAwsIoTNetworkRequest &) = default;
 
@@ -29,7 +29,8 @@ public:
 private:
     void signRequest(const QString &region, const QString &hostname, const QString &serviceName,
                      const QString &accessKeyId, const QString &secretAccessKey,
-                     const QString &sessionToken);
+                     const QString &sessionToken,
+                     qint64 timestamp);
     QString createHashedCanonicalRequest(const QString &canonicalHeaders,
                                          const QString &signedHeaders) const;
     QByteArray getSignatureKey(const QString &secretAccessKey, const QString &date,


### PR DESCRIPTION
Topic paths are dependent upon the namespace and environment the agent is connecting to.
To avoid having the agent to construct these paths itself, the paths are instead returned in the access ticket.
The agent now only has to connect to the frontdoorservice in the correct namespace and environment in order to get the correct topic paths.